### PR TITLE
Added Destroy the Evidence, Pentad Prism (spent mana tracking), track…

### DIFF
--- a/problems/oops/legacyOops.dec
+++ b/problems/oops/legacyOops.dec
@@ -15,9 +15,10 @@ Simian Spirit Guide
 Summoner's Pact
 Chancellor of the Tangle
 
-//3 mana filtering effects
+//4 mana filtering effects
 Wild Cantor > Manamorphose
 Throne of Eldraine
+Pentad Prism
 
 //6 ritual effects of varying quality
 Cabal Ritual

--- a/src/main/prolog/mana.pl
+++ b/src/main/prolog/mana.pl
@@ -13,9 +13,11 @@ makemana([START_HAND, START_BOARD, START_MANA, START_GY, START_STORM, START_DECK
     get_assoc(cost, CARD, COST),
     remove_first(NAME, START_HAND, NEXT_HAND),
     spend(COST, START_MANA, NEXT_MANA),
+    diff_mana(START_MANA, NEXT_MANA, SPENT_MANA),
     cast(NAME, YIELD, EXTRA_STEPS,
     	[NEXT_HAND, START_BOARD, NEXT_MANA, START_GY, START_STORM, START_DECK, START_PROTECTION],
-    	[CAST_HAND, CAST_BOARD, CAST_MANA, CAST_GY, CAST_STORM, CAST_DECK, CAST_PROTECTION]),
+    	[CAST_HAND, CAST_BOARD, CAST_MANA, CAST_GY, CAST_STORM, CAST_DECK, CAST_PROTECTION],
+        SPENT_MANA),
     append(PRIOR_SEQUENCE, [NAME|EXTRA_STEPS], CAST_SEQUENCE),
     addmana(YIELD, CAST_MANA, RESULT_MANA),
     makemana([CAST_HAND, CAST_BOARD, RESULT_MANA, CAST_GY, CAST_STORM, CAST_DECK, CAST_PROTECTION],
@@ -75,9 +77,11 @@ makemana_goal(TARGET_CARD_NAME,
     list_to_assoc(DATA, CARD),
     get_assoc(cost, CARD, COST),
     spend(COST, START_MANA, NEXT_MANA),
+    diff_mana(START_MANA, NEXT_MANA, SPENT_MANA),
     cast(NAME, YIELD, EXTRA_STEPS,
     	[NEXT_HAND, START_BOARD, NEXT_MANA, START_GY, START_STORM, START_DECK, START_PROTECTION],
-    	[CAST_HAND, CAST_BOARD, CAST_MANA, CAST_GY, CAST_STORM, CAST_DECK, CAST_PROTECTION]),
+    	[CAST_HAND, CAST_BOARD, CAST_MANA, CAST_GY, CAST_STORM, CAST_DECK, CAST_PROTECTION],
+        SPENT_MANA),
     append(PRIOR_SEQUENCE, [NAME|EXTRA_STEPS], INTERMEDIATE_SEQUENCE),
     addmana(YIELD, CAST_MANA, RESULT_MANA),
     makemana_goal(TARGET_CARD_NAME,
@@ -349,6 +353,16 @@ spendHybrid(N, START_MANA, END_MANA) :-
     M is N - 1,
     spendHybrid(M, M2, END_MANA).
 noColorless([_, _, _, _, _, 0 | _]).
+
+% Get the exact mana spent
+diff_mana([], [], []).
+diff_mana([H|T], [], [H|T]).
+diff_mana([H | T1], [H | T2], [0 | T3]) :-
+    diff_mana(T1, T2, T3).
+diff_mana([H1 | T1], [H2 | T2], [H3 | T3]) :-
+    H1 > H2,
+    H3 is H1 - H2,
+    diff_mana(T1, T2, T3).
 
 spendArbitraryHybrid(0, START_MANA, START_MANA).
 spendArbitraryHybrid(N, START_MANA, END_MANA) :-

--- a/src/main/prolog/oops_test.pl
+++ b/src/main/prolog/oops_test.pl
@@ -1,8 +1,7 @@
 load_oops :-
     consult('mana.pl'),
     consult('cards.pl'),
-    consult('oops.pl'),
-    consult('test.pl').
+    consult('oops.pl').
 
 run_oops_tests :-
     load_oops,
@@ -19,8 +18,11 @@ run_oops_tests :-
     test_wish_led,
     test_etw,
     test_beseech,
+    test_destroy,
     test_throne,
-    test_makemana_goal(_, _).
+    test_pentad,
+    test_makemana_goal(_, _),
+    !.
 
 % Should be a simple win, but can take up to 5 minutes to process because of trivial choices
 test_hand_1 :-
@@ -266,17 +268,17 @@ test_beseech :-
     LIBRARY = ['Balustrade Spy', 'Narcomoeba', 'Narcomoeba', 'Thassa\'s Oracle', 'Dread Return'],
     HAND = ['Beseech the Mirror', 'Dark Ritual', 'Agadeem\'s Awakening', 'Elvish Spirit Guide'],
     not(hand_wins_(HAND, LIBRARY, [], 0, 0)),
-    hand_wins_(['Mox Opal'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
-    hand_wins_(['Chrome Mox'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
-    hand_wins_(['Lotus Petal'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
-    hand_wins_(['Lion\'s Eye Diamond'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
-    hand_wins_(['Shield Sphere'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
+    hand_wins_(['Mox Opal'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Mox Opal'}),
+    hand_wins_(['Chrome Mox'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Chrome Mox'}),
+    hand_wins_(['Lotus Petal'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Lotus Petal_unused'}),
+    hand_wins_(['Lion\'s Eye Diamond'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Lion\'s Eye Diamond_unused'}),
+    hand_wins_(['Shield Sphere'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Shield Sphere'}),
     not(hand_wins_(['Shuko'|HAND], LIBRARY, [], 0, 0)),
-    hand_wins_(['Simian Spirit Guide'|['Shuko'|HAND]], LIBRARY, [], 0, 0, 'beseech->spy'),
-    hand_wins_(['Leyline of Lifeforce'|HAND], LIBRARY, [], 0, 0, 'beseech->spy'),
+    hand_wins_(['Simian Spirit Guide'|['Shuko'|HAND]], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Shuko'}),
+    hand_wins_(['Leyline of Lifeforce'|HAND], LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Leyline of Lifeforce'}),
     not(hand_wins_(['Leyline of Lifeforce'|HAND], LIBRARY, [], 0, 1)),
     HAND_2 = ['Beseech the Mirror', 'Defense Grid', 'Dark Ritual', 'Agadeem\'s Awakening', 'Elvish Spirit Guide', 'Dark Ritual'],
-    hand_wins_(HAND_2, LIBRARY, [], 0, 0, 'beseech->spy'),
+    hand_wins_(HAND_2, LIBRARY, [], 0, 0, 'beseech->spy', _{bargain: 'Defense Grid'}),
     not(hand_wins_(HAND_2, LIBRARY, [], 0, 1)).
 
 % Throne of Eldraine
@@ -288,15 +290,54 @@ test_throne :-
     hand_wins_(['Beseech the Mirror'|HAND], ['Balustrade Spy'|LIBRARY], [], 0, 0, 'beseech->spy'),
     not(hand_wins_(['Beseech the Mirror'|HAND], ['Undercity Informer'|LIBRARY], [], 0, 0)).
 
-hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION, WINCON) :-
+% Pentad Prism
+test_pentad :-
+    LIBRARY = ['Narcomoeba', 'Narcomoeba', 'Thassa\'s Oracle', 'Dread Return'],
+    HAND = ['Pentad Prism', 'Balustrade Spy', 'Simian Spirit Guide', 'Rite of Flame'],
+    not(hand_wins_(['Rite of Flame'|HAND], LIBRARY, [], 0, 0)),
+    hand_wins_(['Simian Spirit Guide'|['Rite of Flame'|HAND]], LIBRARY, [], 0, 0, spy),
+    hand_wins_(['Elvish Spirit Guide'|['Elvish Spirit Guide'|HAND]], LIBRARY, [], 0, 0, spy),
+    HAND2 = ['Pentad Prism', 'Balustrade Spy', 'Narcomoeba', 'Chrome Mox', 'Dark Ritual', 'Chancellor of the Tangle'],
+    hand_wins_(HAND2, LIBRARY, [], 0, 0, spy),
+    HANDB = ['Pentad Prism', 'Beseech the Mirror', 'Simian Spirit Guide', 'Elvish Spirit Guide', 'Elvish Spirit Guide', 'Lotus Petal'],
+    hand_wins_(HANDB, ['Balustrade Spy'|LIBRARY], [], 0, 0, 'beseech->spy'),
+    HANDB2 = ['Beseech the Mirror', 'Pentad Prism', 'Dark Ritual', 'Agadeem\'s Awakening'],
+    not(hand_wins_(['Cabal Ritual'|HANDB2], ['Balustrade Spy'|LIBRARY], [], 0, 0)),
+    hand_wins_(['Dark Ritual'|HANDB2], ['Balustrade Spy'|LIBRARY], [], 0, 0, 'beseech->spy'),
+    HANDB3 = ['Beseech the Mirror', 'Pentad Prism', 'Simian Spirit Guide', 'Elvish Spirit Guide', 'Chrome Mox', 'Narcomoeba'],
+    not(hand_wins_(['Emeria\'s Call'|HANDB3], ['Balustrade Spy'|LIBRARY], [], 0, 0)),
+    hand_wins_(['Agadeem\'s Awakening'|HANDB3], ['Balustrade Spy'|LIBRARY], [], 0, 0, 'beseech->spy').
+
+% Destroy the Evidence
+test_destroy :-
+    LIBRARY = ['Narcomoeba', 'Narcomoeba', 'Thassa\'s Oracle', 'Dread Return'],
+    HAND = ['Dark Ritual', 'Lotus Petal', 'Destroy the Evidence'],
+    not(hand_wins_(['Agadeem\'s Awakening'|HAND], ['Narcomoeba'|LIBRARY], [], 0, 0)),
+    not(hand_wins_(['Lotus Petal'|['Agadeem\'s Awakening'|HAND]], LIBRARY, [], 0, 0)),
+    not(hand_wins_(['Lotus Petal'|['Elvish Spirit Guide'|HAND]], ['Narcomoeba'|LIBRARY], [], 0, 0)),
+    hand_wins_(['Lotus Petal'|['Agadeem\'s Awakening'|HAND]], ['Narcomoeba'|LIBRARY], [], 0, 0, destroy),
+    hand_wins_(['Lotus Petal'|['Sea Gate Restoration'|HAND]], ['Narcomoeba'|LIBRARY], [], 0, 0, destroy).
+
+hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION, WINCON, REQUIRED_OUTPUTS) :-
     format('~w\n', [HAND]),
     play_oops_hand(HAND, LIBRARY, SB, MULLIGANS, _{protection:1}, OUTPUTS),
     format(' -->~w (~wx protection)\n', [OUTPUTS.sequence, OUTPUTS.protection]),
     PROTECTION is OUTPUTS.protection,
-    WINCON = OUTPUTS.wincon.
+    WINCON = OUTPUTS.wincon,
+    subdict(REQUIRED_OUTPUTS, OUTPUTS).
+
+hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION, WINCON) :-
+    hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION, WINCON, _{}).
 
 hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION) :-
     hand_wins_(HAND, LIBRARY, SB, MULLIGANS, PROTECTION, _).
+
+subdict(DICT_A, DICT_B) :-
+    is_dict(DICT_A),
+    is_dict(DICT_B),
+    dict_pairs(DICT_A, _, PAIRS_A),
+    dict_pairs(DICT_B, _, PAIRS_B),
+    subset(PAIRS_A, PAIRS_B).
 
 % Goal-oriented mana generation should be relatively quick despite many trivial options
 test_makemana_goal(STATE, SEQUENCE) :-


### PR DESCRIPTION
Adds Pentad Prism to logic and decklist, requiring updated logic for tracking spent mana.
Adds reporting of arbitrary key/value pairs, for now just what was sacrificed to Beseech the Mirror.
Adds Destroy the Evidence to the logic for completeness, but not to the decklist template (5CC win condition which requires a land).